### PR TITLE
Update seed, implement create user functionality

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'puma', '~> 3.11'
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'
 # Use ActiveModel has_secure_password
-# gem 'bcrypt', '~> 3.1.7'
+gem 'bcrypt'
 
 # Use ActiveStorage variant
 # gem 'mini_magick', '~> 4.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
+    bcrypt (3.1.18)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -175,6 +176,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  bcrypt
   bootsnap (>= 1.1.0)
   factory_bot_rails
   faker

--- a/app/graphql/mutations/users/create_user.rb
+++ b/app/graphql/mutations/users/create_user.rb
@@ -2,12 +2,14 @@ module Mutations
   module Users 
     class CreateUser < ::Mutations::BaseMutation
       argument :username, String, required: true
+      argument :password, String, required: true
+      argument :password_confirmation, String, required: true
 
       field :user, Types::UserType, null: false
       field :errors, [String], null:false
 
-      def resolve(username:)
-        user = User.create(username: username)
+      def resolve(username:, password:, password_confirmation:)
+        user = User.create(username: username, password: password, password_confirmation: password_confirmation)
 
         if user.save
           {

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -3,6 +3,7 @@ module Types
     field :create_characteristic, mutation: Mutations::Characteristics::CreateCharacteristic
     field :create_character, mutation: Mutations::Characters::CreateCharacter
     field :create_skill, mutation: Mutations::Skills::CreateSkill
+    field :create_user, mutation: Mutations::Users::CreateUser
     field :update_skill, mutation: Mutations::Skills::UpdateSkill
   end
 end

--- a/app/graphql/types/user_type.rb
+++ b/app/graphql/types/user_type.rb
@@ -3,6 +3,8 @@ module Types
     field :characters, [Types::CharacterType], null: true
     field :id, ID, null: false
     field :username, String, null: true
+    field :password, String, null: true
+    field :password_confirmation, String, null: true
     field :created_at, GraphQL::Types::ISO8601DateTime, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,7 @@
 class User < ApplicationRecord
+  has_secure_password
+  validates :username, presence: true, uniqueness: true
+  validates :password, presence: true, length: { minimum: 8 }
+  validates :password_confirmation, presence: true
   has_many :characters, dependent: :destroy
 end

--- a/db/migrate/20221211151104_add_password_digest_to_users.rb
+++ b/db/migrate/20221211151104_add_password_digest_to_users.rb
@@ -1,0 +1,5 @@
+class AddPasswordDigestToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :password_digest, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_27_193711) do
+ActiveRecord::Schema.define(version: 2022_12_11_151104) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -135,6 +135,7 @@ ActiveRecord::Schema.define(version: 2021_08_27_193711) do
     t.string "username"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "password_digest"
   end
 
   create_table "weapons", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,1 @@
-User.destroy_all
-
 User.create(username: 'Dice Master')

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,1 +1,89 @@
-User.create(username: 'Dice Master')
+# Users
+id = User.find_by(username: 'Dice Master').try(:id)
+
+user_1 = id ? User.find(id) : User.create!(username: 'Dice Master', 
+                                           password: 'Test_1234!',
+                                           password_confirmation: 'Test_1234!')
+
+# Characters
+character_1 = user_1.characters.find_or_create_by!(name: 'Anya Forger', 
+                                               species: 'Mystic', 
+                                               specialization: 'Mind Reading', 
+                                               career: 'Peace Keeper',
+                                               age: 4,
+                                               height: '3 feet 4 inches',
+                                               build: 'Ummmm, child?',
+                                               hair: 'pink',
+                                               eyes: 'green')
+
+# Characteristics
+characteristics_1 = character_1.characteristics.find_or_create_by!(brawn: 1,
+                                                                   agility: 2,
+                                                                   char_presence: 1,
+                                                                   cunning: 4,
+                                                                   intellect: 2,
+                                                                   willpower: 4)
+
+# Critical Injuries
+critical_injury_1 = character_1.critical_injuries.find_or_create_by!(severity: 1,
+                                                                       result: 'Tis but a scratch')
+
+# Equipment Logs
+equipment_log_1 = character_1.equipment_logs.find_or_create_by!(credits: '33',
+                                                                 weapons: 'Silenced Pistol',
+                                                                 armor: 'Plot Armor',
+                                                                 personal_gear: 'Peeeaaaaanuts'
+                                                                 )
+
+# Motivations
+motivation_1 = character_1.motivations.find_or_create_by!(mo_type: 'World peace!')
+
+# Obligations
+obligation_1 = character_1.obligations.find_or_create_by!(ob_type: 'Blood Pact',
+                                                          magnitude: 1)
+
+# Skills
+skills_1 = character_1.skills.find_or_create_by!(astrogation: 1,
+                                                 athletics: 1,
+                                                 charm: 5,
+                                                 coercion: 5,
+                                                 computers: 1,
+                                                 cool: 5,
+                                                 coordination: 1,
+                                                 deception: 5,
+                                                 discipline: 1,
+                                                 leadership: 5,
+                                                 mechanics: 1,
+                                                 negotiation: 5,
+                                                 perception: 5,
+                                                 piloting: 1,
+                                                 piloting_space: 1,
+                                                 resilience: 5,
+                                                 skulduggery: 1,
+                                                 stealth: 5,
+                                                 street_wise: 5,
+                                                 survival: 5,
+                                                 vigilance: 5,
+                                                 brawl: 5,
+                                                 gunnery: 2,
+                                                 melee: 5,
+                                                 ranged_light: 3,
+                                                 ranged_heavy: 2,
+                                                 core_worlds: 2,
+                                                 education: 3,
+                                                 lore: 4,
+                                                 outer_rim: 3,
+                                                 underworld: 2,
+                                                 xenology: 1,
+                                                 medicine: 2)
+# Talents
+talent_1 = character_1.talents.find_or_create_by(name: 'Mind Reading',
+                                                 page_number: 55,
+                                                 ability_summary: 'Waku waku I can read your MIND!')
+
+# Weapons
+weapon_1 = character_1.weapons.find_or_create_by!(skill: 'Ranged Light',
+                                                  special: 'Piercing Shot',
+                                                  damage: 5,
+                                                  range: 2,
+                                                  critical: 1)


### PR DESCRIPTION
Ended up going with just `Bcrypt` rather than `Devise`. In reading, `Devise` doesn't seem to be optimized for API only apps, and works much better when the views are handled within rails as well. It's possible, BUT seemed like a headache. Anyways! `Devise` uses `Bcrypt`, so if we go forward and want to plug it in, it shouldn't be too much of a headache. `Create user` is currently functional via `GraphQL` and `GraphiQL mutations`. The only `complexity requirement` we currently implement is a `length of 8`, but will add more as time goes on! 