### PR TITLE
Add user login

### DIFF
--- a/app/graphql/mutations/users/login_user.rb
+++ b/app/graphql/mutations/users/login_user.rb
@@ -1,0 +1,25 @@
+module Mutations
+  module Users
+    class LoginUser < ::Mutations::BaseMutation
+      null true 
+
+      argument :credentials, Types::AuthProviderCredentialsInput, required: false
+
+      field :token, String, null: true
+      field :user, Types::UserType, null: true
+
+      def resolve(credentials: nil)
+        #basic validation
+        return unless credentials
+        user = User.find_by username: credentials[:username]
+
+        return unless user
+        return unless user.authenticate(credentials[:password])
+        crypt = ActiveSupport::MessageEncryptor.new(Rails.application.credentials.secret_key_base.byteslice(0..31))
+        token = crypt.encrypt_and_sign("user-id:#{ user.id }")
+
+      { user: user, token: token }
+      end
+    end
+  end
+end

--- a/app/graphql/types/auth_provider_credentials_input.rb
+++ b/app/graphql/types/auth_provider_credentials_input.rb
@@ -1,0 +1,8 @@
+module Types
+  class AuthProviderCredentialsInput < BaseInputObject
+    graphql_name 'AUTH_PROVIDER_CREDENTIALS'
+
+    argument :email, String, required: true
+    argument :password, String, required: true
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -8,6 +8,7 @@ module Types
     field :create_talent, mutation: Mutations::Talents::CreateTalent
     field :create_user, mutation: Mutations::Users::CreateUser
     field :create_weapon, mutation: Mutations::Weapons::CreateWeapon
+    field :login_user, mutation: Mutations::Users::LoginUser
 
     # Update
     field :update_skill, mutation: Mutations::Skills::UpdateSkill

--- a/spec/graphql/mutations/users/login_user_spec.rb
+++ b/spec/graphql/mutations/users/login_user_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe 'LoginUser', type: :request do
+  describe '.resolve' do  
+    describe 'happy path' do
+      it 'logs user in successfully' do
+        user = create_user 
+
+        result = perform(
+          credentials: {
+            username: user.username,
+            password: user.password
+          }
+        )
+
+        expect(result[:token]).present?
+        expect(result[:user]).to eq(user) 
+      end
+    end
+    
+    describe 'sad path' do
+      it 'does not login user when credentials are missing' do
+        expect(perform).to be_nil
+      end
+
+      it 'does not login user when username is incorrect' do
+        user = create_user
+
+        result = perform(
+          credentials: { 
+            username: 'Wil', 
+            password: user.password,
+          }
+        )
+
+        expect(result).to be_nil
+      end
+
+      it 'does not login user when password is incorrect' do
+        user = create_user
+
+        result = perform(
+          credentials: { 
+            username: user.username,
+            password: "123445678",
+          }
+        )
+
+        expect(result).to be_nil
+      end
+    end
+    
+  private
+
+    def create_user
+      user = User.create!(
+        username: "Will", 
+        password: "12345678",
+        password_confirmation: "12345678"
+      )
+    end
+
+    def perform(args = {})
+      Mutations::Users::LoginUser.new(object: nil, field: nil, context: { session: {} }).resolve(**args)
+    end
+  end
+end


### PR DESCRIPTION
# <!--- Branch -->

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature <!---  non-breaking change which adds functionality -->
- [ ] Refactor
- [ ] Bugfix <!---  fix non-breaking change which fixes an issue -->
- [ ] Documentation

## About
This PR adds logic to allow users to login. It also introduces an `AuthProviderCredentialsInput` class to abstract the input necessary for authentication. 

## Details
I was following the guide from the GraphQL docs to set up server side authentication: https://www.howtographql.com/graphql-ruby/4-authentication/

## Concern
This PR is missing error handling for logging in. I think the error messages for create user could be clearer too.